### PR TITLE
↩️ Pass execute config to deploy callback

### DIFF
--- a/docs/source/syntax.rst
+++ b/docs/source/syntax.rst
@@ -21,8 +21,8 @@ Let's learn Mars features syntax by looking at the example.
 Just like any TS file, Mars scripts start with imports. On line 1, we import Mars helper functions that we aim to use in the script.
 On second line, we can see import of generated :ref:`artifacts <artifacts>`.
 
-``deploy(options: Options, callback: (deployer: string) => void)``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``deploy(options: Options, callback: (deployer: string, config: Config) => void)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On line 4, the ``deploy`` function is called. This is the main entry point of the script.
 
@@ -53,7 +53,31 @@ On line 4, the ``deploy`` function is called. This is the main entry point of th
 ``callback``
 """"""""""""
 
-Function where deployment logic is passed. It may provide an address of the deployer.
+.. code-block:: typescript
+
+   type Callback = (deployer: string, options: ExecuteOptions) => void
+
+.. note::
+
+Function where deployment logic is passed. It may provide an address of the deployer and options of the deployment execution.
+
+``ExecuteOptions``
+""""""""""
+
+.. code-block:: typescript
+
+   interface ExecuteOptions extends TransactionOptions {
+      network: string
+      deploymentsFile: string
+      dryRun: boolean
+      verification?: {
+         etherscanApiKey: string
+         jsonInputs: JsonInputs
+         waffleConfig: string
+      }
+   }
+
+.. note::
 
 .. important::
 

--- a/packages/mars/src/deploy.ts
+++ b/packages/mars/src/deploy.ts
@@ -4,13 +4,13 @@ import { execute, ExecuteOptions } from './execute/execute'
 
 export async function deploy<T>(
   options: Options,
-  callback: (deployer: string) => T
+  callback: (deployer: string, options: ExecuteOptions) => T
 ): Promise<{ result: T } & { config: ExecuteOptions }> {
   const config = await getConfig(options)
 
   context.enabled = true
   context.actions = []
-  const result = callback(config.wallet.address)
+  const result = callback(config.wallet.address, config)
   context.enabled = false
   await execute(context.actions, config)
   return { result, config }


### PR DESCRIPTION
Closes #28 It adds the documentation as well, but I'm not sure if the documentation is written correctly.