### PR TITLE
🖐 Manually schedule a version bump to 0.1.11 with multisig support

### DIFF
--- a/.changeset/tasty-bats-notice.md
+++ b/.changeset/tasty-bats-notice.md
@@ -1,0 +1,5 @@
+---
+'ethereum-mars': patch
+---
+
+Experimental support for multisig deployments via Gnosis Safe


### PR DESCRIPTION
That's also a test for changeset feature recently adopted in this repo.