### PR TITLE
🚎 Automatically approve tx after proposing

### DIFF
--- a/.changeset/thirty-waves-brake.md
+++ b/.changeset/thirty-waves-brake.md
@@ -1,0 +1,5 @@
+---
+'ethereum-mars': patch
+---
+
+Approve multisig just after proposing tx batch

--- a/packages/mars/.nycrc
+++ b/packages/mars/.nycrc
@@ -9,7 +9,7 @@
   ],
   "check-coverage": true,
   "branches": 63,
-  "lines": 70,
+  "lines": 69,
   "functions": 59,
   "statements": 69
 }

--- a/packages/mars/.nycrc
+++ b/packages/mars/.nycrc
@@ -10,6 +10,6 @@
   "check-coverage": true,
   "branches": 63,
   "lines": 69,
-  "functions": 59,
+  "functions": 58,
   "statements": 69
 }

--- a/packages/mars/src/multisig/multisig.ts
+++ b/packages/mars/src/multisig/multisig.ts
@@ -127,6 +127,17 @@ export class MultisigExecutable {
   }
 
   /**
+   * Adds one more approval for a given multisig tx by the current signer. The signer must be authorized to approve.
+   * @param id identifies the multisig transaction to approve
+   */
+  public async approve(id: string): Promise<void> {
+    const safe = await this.ensureSafe()
+    const confirmationSignature = await safe.signTransactionHash(id)
+    await this._safeServiceClient.confirmTransaction(id, confirmationSignature.data)
+    log(`[MULTISIG] Approved ${id} by ${await this._signer.getAddress()}`)
+  }
+
+  /**
    * Returns info about the state of the multisig.
    * @param id multisig identifier
    */

--- a/packages/mars/src/syntax/multisig.ts
+++ b/packages/mars/src/syntax/multisig.ts
@@ -93,8 +93,9 @@ export class MultisigContext {
         log(`Skipping multisig '${executable.name}' due to empty tx set.'`)
         return { continue: true }
       }
-      // TODO: propose and confirm to appear in the queue, see: https://github.com/gnosis/safe-core-sdk/issues/130
+      // two separate calls - not perfect, in order to optimize see: https://github.com/gnosis/safe-core-sdk/issues/130
       const multisigId = await executable.propose(this._current!.txBatch)
+      await executable.approve(multisigId)
       state = {
         id: multisigId,
         state: 'PROPOSED',


### PR DESCRIPTION
Before we had to manually approve tx to see it in the Gnosis Safe Queue.
This PR improves that.

This removes the possibility of delegates to propose (as they need to approve afterwards which Gnosis disallows)

Please see: https://github.com/gnosis/safe-core-sdk/issues/130